### PR TITLE
Only load `Railtie` integration if `Rails::Railtie` is defined (#319)

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -79,7 +79,7 @@ module Config
 end
 
 # Rails integration
-require('config/integrations/rails/railtie') if defined?(::Rails)
+require('config/integrations/rails/railtie') if defined?(::Rails::Railtie)
 
 # Sinatra integration
 require('config/integrations/sinatra') if defined?(::Sinatra)


### PR DESCRIPTION
Co-authored-by: Ufuk Kayserilioglu <ufuk.kayserilioglu@shopify.com>